### PR TITLE
Allow file access as default

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -197,7 +197,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     settings.setDomStorageEnabled(true);
     settings.setSupportMultipleWindows(true);
 
-    settings.setAllowFileAccess(false);
+    settings.setAllowFileAccess(true);
     settings.setAllowContentAccess(false);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
       settings.setAllowFileAccessFromFileURLs(false);


### PR DESCRIPTION
Fix https://github.com/lunascape/phoebe-mobile/issues/1614

react-native-webview set default value for`allowFileAccess` is `false`.
At the same time when mounting webview, it also set `source` to webview.
If source is a local file, and set source is called before enable file access, we will get access_denied error.

We should set default for the setting to `true` as android native webview also does that
https://developer.android.com/reference/android/webkit/WebSettings.html#setAllowFileAccess(boolean)
