### PR TITLE
Load adblockRules in native code instead of pass from JS side

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -584,18 +584,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     ((RNCWebView) view).setHasScrollEvent(hasScrollEvent);
   }
 
-  @ReactProp(name = "adblockRules")
-  public void setAdblockRules(WebView view, @Nullable String rules) {
-    RNCWebViewClient client = ((RNCWebView) view).getRNCWebViewClient();
-    if (client != null) {
-      client.setAdblockRules(rules);
-    }
-  }
-
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
-    view.setWebViewClient(new RNCWebViewClient());
+    RNCWebViewClient client = new RNCWebViewClient();
+    client.setAdblockRules(getModule(reactContext).getAdblockRules());
+    view.setWebViewClient(client);
   }
 
   @Override

--- a/ios/RNCWebViewManager.m
+++ b/ios/RNCWebViewManager.m
@@ -35,6 +35,7 @@ RCT_ENUM_CONVERTER(UIScrollViewContentInsetAdjustmentBehavior, (@{
   NSConditionLock* createNewWindowCondition;
   BOOL createNewWindowResult;
   RNCWebView* newWindow;
+  NSString* contentRuleList;
 }
 
 RCT_EXPORT_MODULE()
@@ -43,6 +44,7 @@ RCT_EXPORT_MODULE()
 {
   RNCWebView *webView = newWindow ? newWindow : [RNCWebView new];
   webView.delegate = self;
+  webView.contentRuleList = contentRuleList;
   newWindow = nil;
   return webView;
 }
@@ -91,8 +93,6 @@ RCT_EXPORT_VIEW_PROPERTY(onNavigationStateChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(messagingEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
-
-RCT_EXPORT_VIEW_PROPERTY(contentRuleList, NSString)
 
 RCT_EXPORT_METHOD(postMessage:(nonnull NSNumber *)reactTag message:(NSString *)message)
 {
@@ -361,6 +361,20 @@ RCT_EXPORT_METHOD(createNewWindowWithResult:(BOOL)result lockIdentifier:(NSInteg
     RCTLogWarn(@"createNewWindowWithResult invoked with invalid lockIdentifier: "
                "got %zd, expected %zd", lockIdentifier, createNewWindowCondition.condition);
   }
+}
+
+RCT_EXPORT_METHOD(loadContentRules:(nonnull NSString *)path
+resolver:(RCTPromiseResolveBlock)resolve
+rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSURL *jsURL = [NSURL fileURLWithPath:path];
+    NSError* error;
+    contentRuleList = [NSString stringWithContentsOfFile:jsURL.path encoding:NSUTF8StringEncoding error:&error];
+    if (error) {
+        reject(@"js_error", @"Error occurred while load content rule list", error);
+    } else {
+        resolve(@(TRUE));
+    }
 }
 
 @end

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -274,7 +274,6 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   textZoom?: number;
   thirdPartyCookiesEnabled?: boolean;
   urlPrefixesForDefaultIntent?: readonly string[];
-  adblockRules?: string;
 }
 
 export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
@@ -298,7 +297,6 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   scrollEnabled?: boolean;
   useSharedProcessPool?: boolean;
   onContentProcessDidTerminate?: (event: WebViewTerminatedEvent) => void;
-  contentRuleList?: string;
 }
 
 export interface IOSWebViewProps extends WebViewSharedProps {
@@ -486,7 +484,6 @@ export interface IOSWebViewProps extends WebViewSharedProps {
   scrollToTop?: boolean;
   lockScroll?: number;
   adjustOffset?: object;
-  contentRuleList?: string;
 }
 
 export interface AndroidWebViewProps extends WebViewSharedProps {
@@ -598,7 +595,6 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * Sets ability to open fullscreen videos on Android devices.
    */
   allowsFullscreenVideo?: boolean;
-  adblockRules?: string;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
@kazkondo @nayuki-at-work I created methods to load adblock files in native code instead of JS.
The result is:
- On iOS, it works ok
- On Android, it crashes but I don't understand why as there is no error logs

Could you please check it?