### PR TITLE
Fix crash of androidHardwareAccelerationDisabled

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -339,13 +339,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "androidHardwareAccelerationDisabled")
   public void setHardwareAccelerationDisabled(WebView view, boolean disabled) {
-    ReactContext reactContext = (ReactContext) view.getContext();
-    final boolean isHardwareAccelerated = (reactContext.getCurrentActivity().getWindow()
-        .getAttributes().flags & WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED) != 0;
-    if (disabled || !isHardwareAccelerated) {
+    if (disabled) {
       view.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
-    } else {
-      view.setLayerType(View.LAYER_TYPE_HARDWARE, null);
     }
   }
 


### PR DESCRIPTION
Fix this crash: https://fabric.io/lunascape-co/android/apps/jp.co.lunascape.android.ilunascape/issues/f03cc23ec955711e6b02ef7064f159cf?time=last-ninety-days
Referring to latest version of react-native-webview: https://github.com/react-native-community/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L287