### PR TITLE
avoid reset WebViewClient

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -598,7 +598,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
-    view.setWebViewClient(new RNCWebViewClient(reactContext));
+    if (((RNCWebView)view).mRNCWebViewClient == null) {
+      view.setWebViewClient(new RNCWebViewClient(reactContext));
+    }
   }
 
   @Override


### PR DESCRIPTION
When a webview is created by window.open, RNCWebViewClient is already configured with correct information.
Setting a new instance may lost adblock config