### PR TITLE
Setup url of main frame correctly

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -860,13 +860,16 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           return null;
         }
 
+        if (request.isForMainFrame()) {
+          mainUrl = url;
+        }
+
         if (adblockEngines != null) {
           BlockerResult blockerResult;
 
           for (Engine engine : adblockEngines) {
             synchronized (engine) {
               if (request.isForMainFrame()) {
-                mainUrl = url;
                 blockerResult = engine.match(url.toString(), url.getHost(), "", false, "");
               } else {
                 blockerResult = engine.match(url.toString(), url.getHost(), mainUrl.getHost(), false, "");


### PR DESCRIPTION
Sometimes, adblock setting is configured before the first request is coming. We have to set `mainUrl` of mainframe regardless adblock setup is completed or not.

The change doesn't effect to other logic.