### PR TITLE
fix(build): Android build errors when using Gradle 6.0 (#1037)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ReactNativeWebView_kotlinVersion=1.3.11
+ReactNativeWebView_kotlinVersion=1.3.50
 ReactNativeWebView_compileSdkVersion=28
 ReactNativeWebView_buildToolsVersion=28.0.3
 ReactNativeWebView_targetSdkVersion=28


### PR DESCRIPTION
* Fix Android build errors when using Gradle 6.0

* Update gradle.properties

* Remove newline at end of file

* newline