### PR TITLE
Develop from 7.2.7 to v11.23.1

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -19,6 +19,12 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.Message;
 import android.os.SystemClock;
+
+import android.print.PrintAttributes;
+import android.print.PrintDocumentAdapter;
+import android.print.PrintDocumentInfo;
+import android.print.PrintJob;
+import android.print.PrintManager;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
@@ -171,6 +177,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   public static final int COMMAND_SEARCH_NEXT = 11;
   public static final int COMMAND_SEARCH_PREVIOUS = 12;
   public static final int COMMAND_REMOVE_ALL_HIGHLIGHTS = 13;
+  public static final int COMMAND_PRINT_CONTENT = 14;
 
   public static final String DOWNLOAD_DIRECTORY = Environment.getExternalStorageDirectory() + "/Android/data/jp.co.lunascape.android.ilunascape/downloads/";
   public static final String TEMP_DIRECTORY = Environment.getExternalStorageDirectory() + "/Android/data/jp.co.lunascape.android.ilunascape/temps/";
@@ -821,6 +828,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       .put("clearFormData", COMMAND_CLEAR_FORM_DATA)
       .put("clearCache", COMMAND_CLEAR_CACHE)
       .put("clearHistory", COMMAND_CLEAR_HISTORY)
+      .put("printContent", COMMAND_PRINT_CONTENT)
       .build();
   }
 
@@ -897,6 +905,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         break;
       case "removeAllHighlights":
         ((RNCWebView) root).removeAllHighlights();
+        break;
+      case "printContent":
+        ((RNCWebView) root).printContent(root);
         break;
     }
     super.receiveCommand(root, commandId, args);
@@ -2044,6 +2055,26 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         e.printStackTrace();
       }
       return jsString;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    @SuppressWarnings("deprecation")
+    public void printContent(WebView webView) {
+
+      PrintManager printManager = (PrintManager) webView.getContext().getSystemService(Context.PRINT_SERVICE);
+
+      String jobName = "Print Document";
+      
+      PrintDocumentAdapter printAdapter;
+      if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        printAdapter = webView.createPrintDocumentAdapter(jobName);
+      }
+      else {
+        printAdapter = webView.createPrintDocumentAdapter();
+      }
+
+      printManager.print(jobName, printAdapter,
+        new PrintAttributes.Builder().build());
     }
 
     public void callInjectedJavaScript() {

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -224,7 +224,10 @@ RCTAutoInsetsProtocol>
 
 - (id)initWithConfiguration:(WKWebViewConfiguration*)configuration from:(RNCWebView*)parentView {
   if (self = [self initWithFrame:parentView.frame]) {
-        _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration: configuration];
+      _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration: configuration];
+      if (parentView.userAgent) {
+      _webView.customUserAgent = parentView.userAgent;
+    }
   }
   return self;
 }

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1061,7 +1061,7 @@ RCTAutoInsetsProtocol>
 
 - (void)setAdjustOffset:(CGPoint)adjustOffset {
   CGRect scrollBounds = _webView.scrollView.bounds;
-  scrollBounds.origin = CGPointMake(0, _webView.scrollView.contentOffset.y + adjustOffset.y);;
+  scrollBounds.origin = CGPointMake(_webView.scrollView.contentOffset.x + adjustOffset.x, _webView.scrollView.contentOffset.y + adjustOffset.y);
   _webView.scrollView.bounds = scrollBounds;
   
   lastOffset = _webView.scrollView.contentOffset;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1353,9 +1353,13 @@ RCTAutoInsetsProtocol>
   
   if (_onShouldStartLoadWithRequest) {
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+    if (request.mainDocumentURL) {
+      [event addEntriesFromDictionary: @{
+        @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
+      }];
+    }
     [event addEntriesFromDictionary: @{
       @"url": (request.URL).absoluteString,
-      @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
       @"navigationType": navigationTypes[@(navigationType)],
       @"isTopFrame": @(isTopFrame)
     }];

--- a/docs/README.portuguese.md
+++ b/docs/README.portuguese.md
@@ -1,4 +1,4 @@
-# React Native WebView - Um moderno, multiplataforma WebView para React Native
+# React Native WebView - Um moderno, WebView multiplataforma para React Native
 
 [![star this repo](http://githubbadges.com/star.svg?user=react-native-webview&repo=react-native-webview&style=flat)](https://github.com/react-native-webview/react-native-webview)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
@@ -6,11 +6,11 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/react-native-webview/react-native-webview/badge.svg?style=flat-square)](https://snyk.io/test/github/react-native-webview/react-native-webview)
 <a href="https://www.npmjs.com/package/react-native-webview"><img src="https://img.shields.io/npm/v/react-native-webview.svg"></a>
 
-**React Native WebView** é um moderno, bem apoiado, e multiplataforma WebView para React Native. É projetado para substituir o WebView embutido(que sera [removido do core](https://github.com/react-native-community/discussions-and-proposals/pull/3)).
+**React Native WebView** é um moderno WebView multiplataforma para React Native. Ele foi projetado para substituir o WebView embutido(que será [removido do core](https://github.com/react-native-community/discussions-and-proposals/pull/3)).
 
-## Mantenedores principais - Empresas Patrocinadoras
+## Principais Mantenedores - Empresas Patrocinadoras
 
-_Esse projeto é mantido gratuitamente por essas pessoas usando ambos seu tempo livre e tempo de trabalho na empresa._
+_Esse projeto é mantido gratuitamente por essas pessoas usando ambos, seu tempo livre e tempo de trabalho na empresa._
 
 - [Thibault Malbranche](https://github.com/Titozzz) ([Twitter @titozzz](https://twitter.com/titozzz)) from [Brigad](https://brigad.co/about)
 - [Jamon Holmgren](https://github.com/jamonholmgren) ([Twitter @jamonholmgren](https://twitter.com/jamonholmgren)) from [Infinite Red](https://infinite.red/react-native)
@@ -49,16 +49,16 @@ Versão atual: ![version](https://img.shields.io/npm/v/react-native-webview.svg)
 - [3.0.0](https://github.com/react-native-webview/react-native-webview/releases/tag/v3.0.0) - WKWebview: Adicionado um pool de processos compartilhados para que os cookies e o localStorage sejam compartilhados nas webviews no iOS (habilitadas por padrão)
 - [2.0.0](https://github.com/react-native-webview/react-native-webview/releases/tag/v2.0.0) - Primeiro lançamento, esta é uma réplica do componente principal do webview.
 
-**Seguinte:**
+**Próximos Passos:**
 
 - Remoção do this.webView.postMessage() (
-  nunca documentado e menos flexível que o injectJavascript) -> [Como migrar](https://github.com/react-native-webview/react-native-webview/issues/809)
+  nunca foi documentado e é menos flexível que o injectJavascript) -> [Como migrar](https://github.com/react-native-webview/react-native-webview/issues/809)
 - Reescrita em Kotlin
 - Talvez reescrita em Swift
 
 ## Uso
 
-Importe o componente `WebView` de `react-native-webview` e use assim:
+Importe o componente `WebView` `react-native-webview` e use assim:
 
 ```jsx
 import React, { Component } from 'react';
@@ -86,7 +86,7 @@ Veja [Contributing.md](https://github.com/react-native-webview/react-native-webv
 
 ## Contribuidores
 
-Obrigado vai a essas pessoas maravilhosas ([emoji key](https://github.com/all-contributors/all-contributors#emoji-key-)):
+Um grande obrigado vai para essas pessoas maravilhosas ([emoji key](https://github.com/all-contributors/all-contributors#emoji-key-)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -9,6 +9,5 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:$androidPluginVersion"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react": "17.0.2",
     "react-native": "0.68.2",
     "react-native-macos": "0.66.57",
-    "react-native-test-app": "1.3.8",
+    "react-native-test-app": "1.5.0",
     "react-native-windows": "0.68.4",
     "selenium-appium": "1.0.2",
     "selenium-webdriver": "4.0.0-alpha.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "11.23.0",
+  "version": "11.23.1",
   "homepage": "https://github.com/react-native-webview/react-native-webview#readme",
   "scripts": {
     "android": "react-native run-android",

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -30,7 +30,7 @@ import styles from './WebView.styles';
 const codegenNativeCommands = codegenNativeCommandsUntyped as <T extends {}>(options: { supportedCommands: (keyof T)[] }) => T;
 
 const Commands = codegenNativeCommands({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'clearFormData', 'clearCache', 'clearHistory', 'loadUrl', 'captureScreen', 'findInPage', 'findNext', 'findPrevious', 'removeAllHighlights'],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'clearFormData', 'clearCache', 'clearHistory', 'loadUrl', 'captureScreen', 'findInPage', 'findNext', 'findPrevious', 'removeAllHighlights', 'printContent'],
 });
 
 const { resolveAssetSource } = Image;
@@ -125,6 +125,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     findNext: () => Commands.findNext(webViewRef.current),
     findPrevious: () => Commands.findPrevious(webViewRef.current),
     removeAllHighlights: () => Commands.removeAllHighlights(webViewRef.current),
+    printContent: () => Commands.printContent(webViewRef.current),
     clearFormData: () => Commands.clearFormData(webViewRef.current),
     clearCache: (includeDiskFiles: boolean) => Commands.clearCache(webViewRef.current, includeDiskFiles),
     clearHistory: () => Commands.clearHistory(webViewRef.current),

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -25,7 +25,8 @@ type WebViewCommands =
   | 'findInPage'
   | 'findNext' 
   | 'findPrevious' 
-  | 'removeAllHighlights';
+  | 'removeAllHighlights'
+  | 'printContent';
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11430,10 +11430,10 @@ react-native-macos@0.66.57:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native-test-app@1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.3.8.tgz#a25c3729a9e6b2a3beb37653d05265a39b5df5ef"
-  integrity sha512-JxPgJ2FsYT9lUMo9bRGpNtTkMZIKpEkXskpdLEk6CliZvO0z5n8z7tlVDDP4AVjJrOlss/OGvfenU88YbLzDfg==
+react-native-test-app@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.5.0.tgz#a504a71246555234a18c02cab454d2a57950e914"
+  integrity sha512-Z+zJjnwnqE/H36aFRKLgjyjrCRanB2R5gN8j33VclBiw9tP6O3lC7iCEewJlKVyRkPzMDOdL0EM18hcx6snqsg==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"


### PR DESCRIPTION
- I picked some commits from https://github.com/gulabs/react-native-webview/commits/dev-7.2.7
- I don't want to pick https://github.com/gulabs/react-native-webview/commit/61420f63adca1e4fae062d6184167dd7bb7a77b0 because react-native-webview (v11.23.0) already has updated typescript
- Update react-native-webview to v11.23.1