### PR TITLE
reimplement injectedJavaScriptBeforeDocumentLoad prop for android 

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/InputStreamWithInjectedJS.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/InputStreamWithInjectedJS.java
@@ -1,102 +1,118 @@
-
 package com.reactnativecommunity.webview;
 
-import android.content.Context;
+import android.annotation.SuppressLint;
 import android.os.Build;
-import androidx.annotation.RequiresApi;
 import android.util.Log;
+
+import androidx.annotation.RequiresApi;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.nio.charset.StandardCharsets.*;
+// ref: https://github.com/MetaMask/metamask-mobile/blob/047e3fec96dff293051ffa8170994739f70b154d/patches/react-native-webview%2B11.13.0.patch#L511
 @RequiresApi(api = Build.VERSION_CODES.KITKAT)
 public class InputStreamWithInjectedJS extends InputStream {
-    private InputStream pageIS;
-    private InputStream scriptIS;
-    private Charset charset;
-    private static final String TAG = "InputStreamWithInjectedJS";
-    private static Map<Charset, String> script = new HashMap<>();
-    private boolean hasJS = false;
-    private boolean headWasFound = false;
-    private boolean scriptWasInjected = false;
-    private boolean openingHeadFound = false;
-    private StringBuffer contentBuffer = new StringBuffer();
-    private static Charset getCharset(String charsetName) {
-        Charset cs = UTF_8;
-        try {
-            if (charsetName != null) {
-                cs = Charset.forName(charsetName);
-            }
-        } catch (UnsupportedCharsetException e) {
-            Log.d("CustomWebview", "wrong charset: " + charsetName);
-        }
-        return cs;
-    }
-    private static InputStream getScript(Charset charset) {
-        String js = script.get(charset);
-        if (js == null) {
-            String defaultJs = script.get(UTF_8);
-            js = new String(defaultJs.getBytes(UTF_8), charset);
-            script.put(charset, js);
-        }
-        return new ByteArrayInputStream(js.getBytes(charset));
-    }
-    InputStreamWithInjectedJS(InputStream is, String js, Charset charset) {
-        if (js == null) {
-            this.pageIS = is;
-        } else {
-            this.hasJS = true;
-            this.charset = charset;
-            Charset cs = UTF_8;
-            String jsScript = "<script>" + js + "</script>";
-            script.put(cs, jsScript);
-            this.pageIS = is;
-        }
-    }
-    @Override
-    public int read() throws IOException {
-        if (scriptWasInjected || !hasJS) {
-            return pageIS.read();
-        }
+  private InputStream pageIS;
+  private InputStream scriptIS;
+  private Charset charset;
+  private static final String REACT_CLASS = "InputStreamWithInjectedJS";
+  private static Map<Charset, String> script = new HashMap<>();
 
-        if (!scriptWasInjected && headWasFound) {
-            int nextByte = scriptIS.read();
-            if (nextByte == -1) {
-                scriptIS.close();
-                scriptWasInjected = true;
-                return pageIS.read();
-            } else {
-                return nextByte;
-            }
-        }
-        if (!headWasFound) {
-            int nextByte = pageIS.read();
-            char nextByteStr =  (char) nextByte;
-            contentBuffer.append(nextByteStr);
-            int bufferLength = contentBuffer.length();
-            String headString = "<head";
-            if(openingHeadFound){
-                 if(nextByte == 62){
-                    this.scriptIS = getScript(this.charset);
-                    headWasFound = true;
-                 }
-            } else {
-                boolean isLetterD = (nextByte == 68 || nextByte == 100);
-                if (isLetterD  && bufferLength >= 5) {
-                    String stringToMatch = contentBuffer.substring(bufferLength - 5).toLowerCase();
-                    if (stringToMatch.contains(headString)) {
-                        openingHeadFound = true;
-                    }
-                }
-            }
-            return nextByte;
-        }
-        return pageIS.read();
+  private boolean hasJS = false;
+  private boolean headWasFound = false;
+  private boolean scriptWasInjected = false;
+
+  private int lowercaseD = 100;
+  private int closingTag = 62;
+  private boolean hasClosingHead = false;
+
+  private StringBuffer contentBuffer = new StringBuffer();
+
+  @SuppressLint("LongLogTag")
+  private static Charset getCharset(String charsetName) {
+    Charset cs = StandardCharsets.UTF_8;
+    try {
+      if (charsetName != null) {
+        cs = Charset.forName(charsetName);
+      }
+    } catch (UnsupportedCharsetException e) {
+      Log.d(REACT_CLASS, "wrong charset: " + charsetName);
     }
+
+    return cs;
+  }
+
+  private static InputStream getScript(Charset charset) {
+    String js = script.get(charset);
+    if (js == null) {
+      String defaultJs = script.get(StandardCharsets.UTF_8);
+      js = new String(defaultJs.getBytes(StandardCharsets.UTF_8), charset);
+      script.put(charset, js);
+    }
+
+    return new ByteArrayInputStream(js.getBytes(charset));
+  }
+
+  InputStreamWithInjectedJS(InputStream is, String js, Charset charset) {
+    if (js == null) {
+      this.pageIS = is;
+    } else {
+      this.hasJS = true;
+      this.charset = charset;
+      Charset cs = StandardCharsets.UTF_8;
+      String jsScript = "<script>" + js + "</script>";
+      script.put(cs, jsScript);
+      this.pageIS = is;
+    }
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (scriptWasInjected || !hasJS) {
+      return pageIS.read();
+    }
+
+    if (!scriptWasInjected && headWasFound) {
+      int nextByte;
+      if (!hasClosingHead) {
+        nextByte = pageIS.read();
+        if (nextByte != closingTag) {
+          return nextByte;
+        }
+        hasClosingHead = true;
+        return nextByte;
+      }
+      nextByte = scriptIS.read();
+      if (nextByte == -1) {
+        scriptIS.close();
+        scriptWasInjected = true;
+        return pageIS.read();
+      } else {
+        return nextByte;
+      }
+    }
+
+    if (!headWasFound) {
+      int nextByte = pageIS.read();
+      contentBuffer.append((char) nextByte);
+      int bufferLength = contentBuffer.length();
+      if (nextByte == lowercaseD && bufferLength >= 5) {
+        if (contentBuffer.substring(bufferLength - 5).equals("<head")) {
+          this.scriptIS = getScript(this.charset);
+          headWasFound = true;
+        }
+      }
+
+      return nextByte;
+    }
+
+    return pageIS.read();
+  }
+
 }


### PR DESCRIPTION
Solution:
`https://github.com/MetaMask/metamask-mobile/pull/2070`

https://github.com/MetaMask/metamask-mobile/blob/047e3fec96dff293051ffa8170994739f70b154d/patches/react-native-webview%2B11.13.0.patch#L415

Related PR: 

https://github.com/gu-corp/react-native-webview/commit/383f6e567cb872c53f7dfbc384091dd2b9c9b460#diff-e9700631fc9fa5600d2e1ee70eb2d28aa2a1fbc695b85f99981972d3904ca485R760

https://github.com/gu-corp/react-native-webview/pull/3/files#diff-e9700631fc9fa5600d2e1ee70eb2d28aa2a1fbc695b85f99981972d3904ca485R856