### PR TITLE
[iOS] Issue: fix bug Pkpass

### DIFF
--- a/ios/DownloadHelper.h
+++ b/ios/DownloadHelper.h
@@ -49,3 +49,11 @@ API_AVAILABLE(ios(11.0))
 
 @end
 
+@interface PendingDownload : NSObject
+
+@property (nonatomic, strong) NSURL *fileUrl;
+@property (nonatomic, strong) NSURLResponse * response;
+
+- (instancetype)initWithFileUrl: (NSURL *)fileUrl response:(NSURLResponse *)response;
+
+@end

--- a/ios/DownloadHelper.m
+++ b/ios/DownloadHelper.m
@@ -147,4 +147,15 @@ static NSMutableDictionary<NSString *, NSMutableArray *> *_blobData = nil;
 
 @end
 
+@implementation PendingDownload
 
+- (instancetype) initWithFileUrl:(NSURL *)fileUrl response:(NSURLResponse *)response {
+    self = [super init];
+    if (self) {
+        _fileUrl = fileUrl;
+        _response = response;
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION
Flow Brave:
1. set shouldDownloadNavigationResponse = true
Brave: https://github.com/brave/brave-ios/blob/398f8b763aa88cdc23289138863d62f05b2c2a23/Sources/Brave/Frontend/Browser/BrowserViewController/BVC%2BWKNavigationDelegate.swift#L438

> if ["http", "https", "data", "blob", "file"].contains(requestURL.scheme) {
>  ...
>  if navigationAction.shouldPerformDownload {
>    self.shouldDownloadNavigationResponse = true
>  }
>  return (.allow, preferences)
>}

2. Check if this response should be handed off to Passbook.
Brave: https://github.com/brave/brave-ios/blob/398f8b763aa88cdc23289138863d62f05b2c2a23/Sources/Brave/Frontend/Browser/BrowserViewController/BVC%2BWKNavigationDelegate.swift#L549

>if shouldDownloadNavigationResponse {
>  shouldDownloadNavigationResponse = false
>
>  if response.mimeType == MIMEType.passbook {
>    return .download
>  }
>}

3. Handle download file Pkpass
Brave: https://github.com/brave/brave-ios/blob/398f8b763aa88cdc23289138863d62f05b2c2a23/Sources/Brave/Frontend/Browser/BrowserViewController/BVC%2BWKNavigationDelegate.swift#L607

4. WKDownloadDelegate
Brave: https://github.com/brave/brave-ios/blob/398f8b763aa88cdc23289138863d62f05b2c2a23/Sources/Brave/Frontend/Browser/BrowserViewController/BVC%2BWKDownloadDelegate.swift