### PR TITLE
fix: high cpu when converting url to domain

### DIFF
--- a/apple/Settings.bundle/AdblockResources/Scripts/RequestBlockingScript.js
+++ b/apple/Settings.bundle/AdblockResources/Scripts/RequestBlockingScript.js
@@ -18,7 +18,7 @@ window.__firefox__.execute(function($) {
       }
     }).then(blocked => {
       if (blocked) {
-        console.info(`Brave prevented frame displaying ${window.location.href} from loading a resource from ${resourceURL.href}`)
+        console.info(`Lunascape prevented frame displaying ${window.location.href} from loading a resource from ${resourceURL.href}`)
       }
       
       return blocked

--- a/apple/lunascape/AdBlock/AdblockRustEngine.swift
+++ b/apple/lunascape/AdBlock/AdblockRustEngine.swift
@@ -32,23 +32,23 @@ class AdblockRustEngine {
     
     private func setDomainResolver() {
         let resolver: C_DomainResolverCallback = { host, start, end in
-            //self.swiftDomainResolver(host: host!, start: start!, end: end!)
-            let hostString = String(cString: host!)
+            guard let host = host, let start = start, let end = end else { return }
+            let hostString = String(cString: host)
 
             // Use DomainParser to get the domain
             if let parsedDomain = DomainResolver.shared.baseDomain(for: hostString) {
                 if let range = hostString.range(of: parsedDomain) {
                     let startIndex = hostString.distance(from: hostString.startIndex, to: range.lowerBound)
                     let endIndex = hostString.distance(from: hostString.startIndex, to: range.upperBound)
-                    start!.pointee = UInt32(startIndex)
-                    end!.pointee = UInt32(endIndex)
+                    start.pointee = UInt32(startIndex)
+                    end.pointee = UInt32(endIndex)
                 } else {
-                    start!.pointee = 0
-                    end!.pointee = UInt32(hostString.count)
+                    start.pointee = 0
+                    end.pointee = UInt32(hostString.count)
                 }
             } else {
-                start!.pointee = 0
-                end!.pointee = UInt32(hostString.count)
+                start.pointee = 0
+                end.pointee = UInt32(hostString.count)
             }
         }
         _ = set_domain_resolver(resolver)

--- a/apple/lunascape/AdBlock/AdblockRustEngine.swift
+++ b/apple/lunascape/AdBlock/AdblockRustEngine.swift
@@ -36,8 +36,7 @@ class AdblockRustEngine {
             let hostString = String(cString: host!)
 
             // Use DomainParser to get the domain
-            if let domainParser = try? DomainParser(),
-               let parsedDomain = domainParser.parse(host: hostString)?.domain {
+            if let parsedDomain = DomainResolver.shared.baseDomain(for: hostString) {
                 if let range = hostString.range(of: parsedDomain) {
                     let startIndex = hostString.distance(from: hostString.startIndex, to: range.lowerBound)
                     let endIndex = hostString.distance(from: hostString.startIndex, to: range.upperBound)
@@ -59,8 +58,7 @@ class AdblockRustEngine {
         let hostString = String(cString: host)
 
         // Use DomainParser to get the domain
-        if let domainParser = try? DomainParser(),
-           let parsedDomain = domainParser.parse(host: hostString)?.domain {
+        if let parsedDomain = DomainResolver.shared.baseDomain(for: hostString) {
             if let range = hostString.range(of: parsedDomain) {
                 let startIndex = hostString.distance(from: hostString.startIndex, to: range.lowerBound)
                 let endIndex = hostString.distance(from: hostString.startIndex, to: range.upperBound)

--- a/apple/lunascape/AdBlock/DomainParser/DomainParser.swift
+++ b/apple/lunascape/AdBlock/DomainParser/DomainParser.swift
@@ -22,9 +22,11 @@ public struct DomainParser: DomainParserProtocol {
     /// Parameters:
     ///   - QuickParsing: IF true, the `exception` and `wildcard` rules will be ignored
     public init(quickParsing: Bool = false) throws {
-        let bundlePath = Bundle.main.path(forResource: "Settings", ofType: "bundle")!
-        let resourceBundle = Bundle(path: bundlePath)
-        let linkList = (resourceBundle?.url(forResource: "AdblockResources/public_suffix_list", withExtension: "dat"))!
+        guard let bundlePath = Bundle.main.path(forResource: "Settings", ofType: "bundle"),
+              let resourceBundle = Bundle(path: bundlePath),
+              let linkList = resourceBundle.url(forResource: "AdblockResources/public_suffix_list", withExtension: "dat") else {
+            throw DomainParserError.ruleParsingError(message: "Missing AdblockResources/public_suffix_list.dat in Settings.bundle")
+        }
         let data = try Data(contentsOf: linkList)
 
         // We don't need to sort the rules from "public_suffix_list" since

--- a/apple/lunascape/AdBlock/DomainParser/DomainResolver.swift
+++ b/apple/lunascape/AdBlock/DomainParser/DomainResolver.swift
@@ -1,0 +1,20 @@
+//
+//  DomainResolver.swift
+//
+
+import Foundation
+
+final class DomainResolver {
+    static let shared = DomainResolver()
+
+    private let lock = NSLock()
+    private lazy var parser: DomainParser? = try? DomainParser()
+
+    private init() {}
+
+    func baseDomain(for host: String) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return parser?.parse(host: host)?.domain
+    }
+}

--- a/apple/lunascape/AdBlock/DomainParser/DomainResolver.swift
+++ b/apple/lunascape/AdBlock/DomainParser/DomainResolver.swift
@@ -7,14 +7,18 @@ import Foundation
 final class DomainResolver {
     static let shared = DomainResolver()
 
-    private let lock = NSLock()
-    private lazy var parser: DomainParser? = try? DomainParser()
+    private let parser: DomainParser?
 
-    private init() {}
+    private init() {
+        do {
+            self.parser = try DomainParser()
+        } catch {
+            NSLog("[DomainResolver] Failed to init DomainParser: \(error)")
+            self.parser = nil
+        }
+    }
 
     func baseDomain(for host: String) -> String? {
-        lock.lock()
-        defer { lock.unlock() }
         return parser?.parse(host: host)?.domain
     }
 }

--- a/apple/lunascape/AdBlock/URLExtension.swift
+++ b/apple/lunascape/AdBlock/URLExtension.swift
@@ -17,8 +17,7 @@ extension URL {
             return host
         }
         
-        let domainParser = try? DomainParser()
-        return domainParser?.parse(host: host)?.domain
+        return DomainResolver.shared.baseDomain(for: host)
     }
     
     init?(idnString: String) {


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->

Fixes #(issue)

Changes:
- Introduced a new DomainResolver singleton to centralize and reuse domain parsing logic, minimizing redundant computations.
- Updated the AdblockRustEngine class to utilize the DomainResolver for more efficient extraction of base domains.
- Modified the DomainParser to include robust null-checks and error handling for missing resources, ensuring graceful handling of exceptions.
- Replaced direct calls to DomainParser with the shared DomainResolver in various extensions, such as URLExtension.
These changes are expected to reduce CPU overhead significantly when working with domain-related operations.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring
- [ ] 🧪 Test update

## Testing
<!-- How was this tested? -->
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Screenshots (if UI change)
| Before | After |
|--------|-------|
|        |       |

## Checklist
- [ ] Self-reviewed my code
- [ ] Added/updated tests
- [ ] Updated documentation (if needed)
- [ ] No new warnings
