### PR TITLE
fix: keep page visible while media is playing (background playback / PiP)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -821,16 +821,44 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
      * because those are global and would freeze every other WebView in the app.
      */
     public void setPageVisibility(boolean visible) {
+        mPageVisible = visible;
         if (visible) {
             // Resume processing first, then mark the view visible so the page
             // receives the "visible" event while the renderer is active.
             onResume();
             setVisibility(View.VISIBLE);
         } else {
-            // Mark the view hidden first so the page receives the "hidden"
-            // event, then pause extra processing to free resources.
-            setVisibility(View.INVISIBLE);
-            onPause();
+            // Background media playback (YouTube audio, Picture in Picture) is a
+            // core product feature, and both the "hidden" event and onPause()
+            // stop it. Only hide the page when no media is playing.
+            evaluateJavascript(IS_MEDIA_PLAYING_SCRIPT, value -> {
+                // The tab may have become active again while the async check ran.
+                if (mPageVisible) {
+                    return;
+                }
+                if ("true".equals(value)) {
+                    return;
+                }
+                // Mark the view hidden first so the page receives the "hidden"
+                // event, then pause extra processing to free resources.
+                setVisibility(View.INVISIBLE);
+                onPause();
+            });
         }
     }
+
+    // Tracks the last requested page visibility so the async media-state check
+    // can detect that the tab became active again before it resolved.
+    private boolean mPageVisible = true;
+
+    // Main-frame check only: media inside cross-origin iframes is not visible to
+    // this script, which matches the main YouTube playback use case.
+    private static final String IS_MEDIA_PLAYING_SCRIPT =
+        "(function(){" +
+        "var media=document.querySelectorAll('video,audio');" +
+        "for(var i=0;i<media.length;i++){" +
+        "if(!media[i].paused&&!media[i].ended&&media[i].readyState>2){return true;}" +
+        "}" +
+        "return false;" +
+        "})()";
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -806,4 +806,31 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         }
         loadUrl(url);
     }
+
+    /**
+     * Drives the W3C Page Visibility API for the page, mirroring the iOS
+     * {@code setPageVisibility} (which detaches/attaches the WKWebView).
+     *
+     * Chromium's WebView derives {@code document.visibilityState} from the
+     * View's visibility, so toggling between VISIBLE and INVISIBLE makes the
+     * page fire a "visibilitychange" event (document.hidden true/false).
+     * We additionally call {@link #onPause()}/{@link #onResume()} so animations,
+     * plugins and geolocation stop while hidden.
+     *
+     * Note: we intentionally avoid {@code pauseTimers()}/{@code resumeTimers()}
+     * because those are global and would freeze every other WebView in the app.
+     */
+    public void setPageVisibility(boolean visible) {
+        if (visible) {
+            // Resume processing first, then mark the view visible so the page
+            // receives the "visible" event while the renderer is active.
+            onResume();
+            setVisibility(View.VISIBLE);
+        } else {
+            // Mark the view hidden first so the page receives the "hidden"
+            // event, then pause extra processing to free resources.
+            setVisibility(View.INVISIBLE);
+            onPause();
+        }
+    }
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -408,6 +408,7 @@ class RNCWebViewManagerImpl {
     // TODO: disable night mode for now because it is unnecessary
     // val COMMAND_SET_ENABLE_NIGHT_MODE = 18 // should update value
     val COMMAND_PROCEED_UNSAFE_SITE = 18
+    val COMMAND_SET_PAGE_VISIBILITY = 19
     // endregion
 
     fun getCommandsMap(): Map<String, Int>? {
@@ -434,6 +435,7 @@ class RNCWebViewManagerImpl {
         .put("setFontSize", COMMAND_SET_FONT_SIZE)
         // .put("setEnableNightMode", COMMAND_SET_ENABLE_NIGHT_MODE) // disable night mode for now because it is unnecessary
         .put("proceedUnsafeSite", COMMAND_PROCEED_UNSAFE_SITE)
+        .put("setPageVisibility", COMMAND_SET_PAGE_VISIBILITY)
         .build()
     }
 
@@ -491,6 +493,7 @@ class RNCWebViewManagerImpl {
         // TODO: disable night mode for now because it is unnecessary
         // "setEnableNightMode" -> webView.setEnableNightMode(args.getString(0)) 
         "proceedUnsafeSite" -> webView.proceedUnsafeSite(args.getString(0))
+        "setPageVisibility" -> webView.setPageVisibility(args.getBoolean(0))
       }
     }
 
@@ -621,6 +624,16 @@ class RNCWebViewManagerImpl {
         view.clearFormData();
         view.settings.savePassword = false;
         view.settings.saveFormData = false;
+    }
+
+    fun setInitPageVisibilityValue(viewWrapper: RNCWebViewWrapper, visible: Boolean) {
+        if (!visible) {
+            // Set the WebView to INVISIBLE 
+            // and pause it to prevent it from loading content in the background and consuming CPU and battery 
+            val view = viewWrapper.webView
+            view.visibility = View.INVISIBLE
+            view.onPause()
+        }
     }
 
     fun setInjectedJavaScript(viewWrapper: RNCWebViewWrapper, injectedJavaScript: String?) {

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -168,6 +168,12 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     }
 
     @Override
+    @ReactProp(name = "initPageVisibilityValue")
+    public void setInitPageVisibilityValue(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setInitPageVisibilityValue(view, value);
+    }
+
+    @Override
     @ReactProp(name = "injectedJavaScript")
     public void setInjectedJavaScript(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScript(view, value);

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -134,6 +134,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         mRNCWebViewManagerImpl.setIncognito(view, value);
     }
 
+    @ReactProp(name = "initPageVisibilityValue")
+    public void setInitPageVisibilityValue(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setInitPageVisibilityValue(view, value);
+    }
+
     @ReactProp(name = "injectedJavaScript")
     public void setInjectedJavaScript(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScript(view, value);

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -316,6 +316,7 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
     REMAP_WEBVIEW_PROP(keyboardDisplayRequiresUserAction)
     // Lunascape
     REMAP_WEBVIEW_PROP(adblockDebuggingEnabled)
+    REMAP_WEBVIEW_PROP(initPageVisibilityValue)
     
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
     REMAP_WEBVIEW_PROP(automaticallyAdjustContentInsets)
@@ -532,6 +533,10 @@ Class<RCTComponentViewProtocol> RNCWebViewCls(void)
 
 - (void)stopLoading {
     [_view stopLoading];
+}
+
+- (void)setPageVisibility:(BOOL)visible {
+    [_view setPageVisibility:visible];
 }
 
 - (void)clearFormData {

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -169,6 +169,7 @@ shouldCreateNewWindow:(NSMutableDictionary<NSString *, id>* _Nonnull)request wit
 // TODO: disable night mode for now because it is unnecessary
 // @property (nonatomic, assign) BOOL initNightModeValue;
 @property (nonatomic, assign) BOOL scrollToTop;
+@property (nonatomic, assign) BOOL initPageVisibilityValue;
 @property (nonatomic, assign) BOOL openNewWindowInWebView;
 @property (nonatomic, assign) CGPoint adjustOffset;
 @property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable additionalUserAgent;
@@ -188,6 +189,7 @@ shouldCreateNewWindow:(NSMutableDictionary<NSString *, id>* _Nonnull)request wit
 // TODO: disable night mode for now because it is unnecessary
 // - (void)setEnableNightMode:(nonnull NSString *)enable;
 - (void)proceedUnsafeSite:(nullable NSString*)url;
+- (void)setPageVisibility:(BOOL)visible;
 
 
 @property (nonatomic, copy) RCTDirectEventBlock onWebViewClosed;

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -223,6 +223,7 @@ RCTAutoInsetsProtocol, WKScriptMessageHandlerWithReply>
     super.backgroundColor = [RCTUIColor clearColor];
 #endif // !TARGET_OS_OSX
     _bounces = YES;
+    _initPageVisibilityValue = YES;
     _scrollEnabled = YES;
     _showsHorizontalScrollIndicator = YES;
     _showsVerticalScrollIndicator = YES;
@@ -673,7 +674,10 @@ RCTAutoInsetsProtocol, WKScriptMessageHandlerWithReply>
       longGesture.delegate = self;
       [_webView addGestureRecognizer:longGesture];
       
-    [self addSubview:_webView];
+    // init page visibility value, if the value is false, we will not attach the webview to view hierarchy 
+    if (_initPageVisibilityValue) {
+      [self addSubview:_webView];
+    }
     [self setHideKeyboardAccessoryView: _savedHideKeyboardAccessoryView];
     [self setKeyboardDisplayRequiresUserAction: _savedKeyboardDisplayRequiresUserAction];
     [self visitSource];
@@ -2615,6 +2619,18 @@ didFinishNavigation:(WKNavigation *)navigation
             NSLog(@"Print FAILED! with error: %@", error.localizedDescription);
         }
     }];
+}
+
+- (void)setPageVisibility:(BOOL)visible {
+    if(visible == TRUE) {
+      // Only add _webView as a subview if it isn't already attached to self.
+      if (_webView != nil && _webView.superview != self) {
+          [self addSubview:_webView];
+      }
+    } else {
+      [_webView removeFromSuperview];
+    }
+    
 }
 
 - (void)longPressed:(UILongPressGestureRecognizer*)sender {

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -157,6 +157,10 @@ RCTAutoInsetsProtocol, WKScriptMessageHandlerWithReply>
   BOOL _savedHideKeyboardAccessoryView;
   BOOL _savedKeyboardDisplayRequiresUserAction;
 
+  // Tracks the last requested page visibility so async media-state checks can
+  // detect that the tab became active again before they resolved.
+  BOOL _pageVisible;
+
   // Workaround for StatusBar appearance bug for iOS 12
   // https://github.com/react-native-webview/react-native-webview/issues/62
   BOOL _isFullScreenVideoOpen;
@@ -224,6 +228,7 @@ RCTAutoInsetsProtocol, WKScriptMessageHandlerWithReply>
 #endif // !TARGET_OS_OSX
     _bounces = YES;
     _initPageVisibilityValue = YES;
+    _pageVisible = YES;
     _scrollEnabled = YES;
     _showsHorizontalScrollIndicator = YES;
     _showsVerticalScrollIndicator = YES;
@@ -674,7 +679,8 @@ RCTAutoInsetsProtocol, WKScriptMessageHandlerWithReply>
       longGesture.delegate = self;
       [_webView addGestureRecognizer:longGesture];
       
-    // init page visibility value, if the value is false, we will not attach the webview to view hierarchy 
+    // init page visibility value, if the value is false, we will not attach the webview to view hierarchy
+    _pageVisible = _initPageVisibilityValue;
     if (_initPageVisibilityValue) {
       [self addSubview:_webView];
     }
@@ -2622,15 +2628,38 @@ didFinishNavigation:(WKNavigation *)navigation
 }
 
 - (void)setPageVisibility:(BOOL)visible {
+    _pageVisible = visible;
     if(visible == TRUE) {
       // Only add _webView as a subview if it isn't already attached to self.
       if (_webView != nil && _webView.superview != self) {
           [self addSubview:_webView];
       }
-    } else {
-      [_webView removeFromSuperview];
+      return;
     }
-    
+#if !TARGET_OS_OSX
+    // Background media playback (YouTube audio, Picture in Picture) is a core
+    // product feature: detaching the WKWebView stops it. When media is playing,
+    // keep the webview attached so the page stays "visible" and playback continues.
+    if (@available(iOS 15.0, *)) {
+      __weak __typeof__(self) weakSelf = self;
+      [_webView requestMediaPlaybackStateWithCompletionHandler:^(WKMediaPlaybackState state) {
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf == nil) {
+          return;
+        }
+        // The tab may have become active again while the async query was in flight.
+        if (strongSelf->_pageVisible) {
+          return;
+        }
+        if (state == WKMediaPlaybackStatePlaying) {
+          return;
+        }
+        [strongSelf->_webView removeFromSuperview];
+      }];
+      return;
+    }
+#endif // !TARGET_OS_OSX
+    [_webView removeFromSuperview];
 }
 
 - (void)longPressed:(UILongPressGestureRecognizer*)sender {

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -88,6 +88,7 @@ RCT_EXPORT_VIEW_PROPERTY(autoManageStatusBarEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsBackForwardNavigationGestures, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(incognito, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(initPageVisibilityValue, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(pagingEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(applicationNameForUserAgent, NSString)
 RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
@@ -422,6 +423,18 @@ RCT_EXPORT_METHOD(printContent:(nonnull NSNumber *)reactTag) {
         }
     }];
 }
+
+RCT_EXPORT_METHOD(setPageVisibility:(nonnull NSNumber *)reactTag visible:(nonnull NSNumber *)visible) {
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCView *> *viewRegistry) {
+        RNCView *view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[RNCWebViewImpl class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting RNCWebView, got: %@", view);
+        } else {
+            [(RNCWebViewImpl *)view setPageVisibility:[visible boolValue]];
+        }
+    }];
+}
+
 
 RCT_EXPORT_METHOD(setFontSize:(nonnull NSNumber *)reactTag size:(nonnull NSNumber *)size) {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -93,6 +93,7 @@ This document lays out the current public properties and methods for the React N
 - [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
 - [`allowsProtectedMedia`](Reference.md#allowsProtectedMedia)
 - [`webviewDebuggingEnabled`](Reference.md#webviewDebuggingEnabled)
+- [`initPageVisibilityValue`](Reference.md#initPageVisibilityValue)
 
 ## Methods Index
 
@@ -106,6 +107,7 @@ This document lays out the current public properties and methods for the React N
 - [`clearHistory`](Reference.md#clearHistory)
 - [`requestFocus`](Reference.md#requestFocus)
 - [`postMessage`](Reference.md#postmessagestr)
+- [`setPageVisibility`](Reference.md#setpagevisibilityvisible)
 
 ---
 
@@ -1718,6 +1720,25 @@ Default is `false`. Supported on iOS as of 16.4, previous versions always allow 
 | ------- | -------- | -------- |
 | boolean | No       | iOS & Android  |
 
+### `initPageVisibilityValue`[⬆](#props-index)
+
+Sets the initial [page visibility](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) state of the web content when the `WebView` is created. The default value is `true`.
+
+When set to `false`, the `WebView` still loads its `source`, but its content is treated as hidden (`document.visibilityState` reports `hidden` and the `visibilitychange` event fires accordingly). This is useful when many `WebView` instances live on a single screen (e.g. a tabbed browser) and you want to avoid the CPU/RAM cost of off-screen pages running as if visible. The visibility state can be updated at runtime with the [`setPageVisibility`](Reference.md#setpagevisibilityvisible) method.
+
+| Type    | Required | Default | Platform      |
+| ------- | -------- | ------- | ------------- |
+| boolean | No       | true    | iOS, Android  |
+
+Example:
+
+```jsx
+<WebView
+  source={{ uri: 'https://reactnative.dev' }}
+  initPageVisibilityValue={false}
+/>
+```
+
 ## Methods
 
 ### `goForward()`[⬆](#methods-index)
@@ -1809,6 +1830,32 @@ clearHistory();
 ```
 
 Tells this WebView to clear its internal back/forward list. [developer.android.com reference](<https://developer.android.com/reference/android/webkit/WebView.html#clearHistory()>)
+
+### `setPageVisibility(visible)`[⬆](#methods-index)
+
+```javascript
+setPageVisibility(true);
+```
+
+Updates the [page visibility](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) state of the web content at runtime. Pass `true` to mark the page as visible or `false` to mark it as hidden. This updates `document.visibilityState` inside the page and fires the `visibilitychange` event, allowing the web content to pause/resume work (animations, timers, media, etc.) when it is not on screen.
+
+Use this together with [`initPageVisibilityValue`](Reference.md#initPageVisibilityValue) to control whether off-screen `WebView` instances behave as visible or hidden.
+
+| Platform     |
+| ------------ |
+| iOS, Android |
+
+Example:
+
+```jsx
+const webviewRef = useRef(null);
+
+// Mark the page as hidden, e.g. when the tab is moved to the background
+webviewRef.current?.setPageVisibility(false);
+
+// Mark the page as visible again when the tab is brought to the foreground
+webviewRef.current?.setPageVisibility(true);
+```
 
 ## Other Docs
 

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -296,6 +296,12 @@ export interface NativeProps extends ViewProps {
    * Enables Adblock debugging. Only available on iOS and Android.
    */
   adblockDebuggingEnabled?: boolean;
+  /**
+   * Initial page visibility state when the webview is created.
+   * When `false`, the webview still loads its source but is not attached/shown,
+   * helping reduce CPU/RAM usage when many webviews live on a single screen.
+   */
+  initPageVisibilityValue?: boolean;
   // TODO: disable night mode for now because it is unnecessary
   // /***
   //  * initial value of night mode
@@ -372,6 +378,10 @@ export interface NativeCommands {
     viewRef: React.ElementRef<HostComponent<NativeProps>>,
     js: string
   ) => void;
+  setPageVisibility: (
+    viewRef: React.ElementRef<HostComponent<NativeProps>>,
+    visible: boolean
+  ) => void;
 }
 
 export const Commands = codegenNativeCommands<NativeCommands>({
@@ -400,6 +410,7 @@ export const Commands = codegenNativeCommands<NativeCommands>({
     // 'setEnableNightMode',
     'proceedUnsafeSite',
     'evaluateJavaScript',
+    'setPageVisibility',
   ],
 });
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -115,6 +115,7 @@ const WebViewComponent = forwardRef<
       webviewDebuggingEnabled,
       openNewWindowInWebView,
       incognito = false,
+      initPageVisibilityValue = true,
       // for testing ids
       accessible,
       accessibilityLabel,
@@ -241,6 +242,10 @@ const WebViewComponent = forwardRef<
         proceedUnsafeSite: (enable: string) => {
           webViewRef.current &&
             Commands.proceedUnsafeSite(webViewRef.current, enable);
+        },
+        setPageVisibility: (visible: boolean) => {
+          webViewRef.current &&
+            Commands.setPageVisibility(webViewRef.current, visible);
         },
         webViewRef: webViewRef.current,
         // #endregion Lunascape
@@ -425,6 +430,7 @@ const WebViewComponent = forwardRef<
         webviewDebuggingEnabled={webviewDebuggingEnabled}
         openNewWindowInWebView={openNewWindowInWebView}
         incognito={incognito}
+        initPageVisibilityValue={initPageVisibilityValue}
         // for testing ids
         accessible={accessible}
         accessibilityLabel={accessibilityLabel}

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -98,6 +98,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
       decelerationRate: decelerationRateProp,
       onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
       // #region Lunascape
+      initPageVisibilityValue = true,
       onCaptureScreen,
       onGetFavicon: onGetFaviconProp,
       onShouldCreateNewWindow: onShouldCreateNewWindowProp,
@@ -226,6 +227,10 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
         },
         getContentTypes: () => {
           return refValiable.current.contentType;
+        },
+        setPageVisibility: (visible: boolean) => {
+          webViewRef.current &&
+            Commands.setPageVisibility(webViewRef.current, visible);
         },
         webViewRef: webViewRef.current,
       }),
@@ -371,6 +376,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
         // @ts-expect-error old arch only
         source={sourceResolved}
         // #region Lunascape
+        initPageVisibilityValue={initPageVisibilityValue}
         onGetFavicon={onGetFavicon}
         onCaptureScreen={onCaptureScreen}
         onShouldCreateNewWindow={onShouldCreateNewWindow}

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -27,7 +27,8 @@ type WebViewCommands =
   | 'printContent'
   | 'setFontSize'
   // | 'setEnableNightMode'
-  | 'proceedUnsafeSite';
+  | 'proceedUnsafeSite'
+  | 'setPageVisibility';
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearFormData';
 
@@ -43,6 +44,7 @@ interface RNCWebViewUIManager<Commands extends string> extends UIManagerStatic {
   setFontSize: (viewTag: number, size: number) => void;
   // setEnableNightMode: (viewTag: number, enable: string) => void;
   proceedUnsafeSite: (viewTag: number, url: string) => void;
+  setPageVisibility: (viewTag: number, visible: boolean) => void;
 }
 
 export type RNCWebViewUIManagerAndroid = RNCWebViewUIManager<
@@ -449,6 +451,15 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * Does not store any data within the lifetime of the WebView.
    */
   incognito?: boolean;
+
+  /**
+   * Initial page visibility state when the webview is created.
+   * When `false`, the webview still loads its source but is not attached/shown,
+   * helping reduce CPU/RAM usage when many webviews live on a single screen.
+   * @platform ios, android
+   * @default true
+   */
+  initPageVisibilityValue?: boolean;
 
   /**
    * Boolean value that determines whether the web view bounces
@@ -1002,6 +1013,15 @@ export interface MacOSWebViewProps extends WebViewSharedProps {
 export interface AndroidWebViewProps extends WebViewSharedProps {
   onNavigationStateChange?: (event: WebViewNavigation) => void;
   onContentSizeChange?: (event: WebViewEvent) => void;
+
+  /**
+   * Initial page visibility state when the webview is created.
+   * When `false`, the webview still loads its source but is not shown (INVISIBLE + onPause),
+   * helping reduce CPU/RAM usage when many webviews live on a single screen.
+   * @platform ios, android
+   * @default true
+   */
+  initPageVisibilityValue?: boolean;
 
   /**
    * Function that is invoked when the `WebView` process crashes or is killed by the OS.


### PR DESCRIPTION
## Summary

`setPageVisibility(false)` currently detaches the WKWebView (iOS) / fires the hidden event and calls `onPause()` (Android). Both stop HTML5 media playback, so switching tabs in the app kills background YouTube playback and Picture in Picture — a core product feature of Lunascape Mobile.

This PR queries the media playback state before hiding the page and skips the hide while media is playing:

- **iOS**: `WKWebView.requestMediaPlaybackState` (iOS 15+). Older iOS keeps the previous unconditional detach.
- **Android**: probes main-frame `<video>` / `<audio>` elements via `evaluateJavascript`. (Media inside cross-origin iframes is not detected — the main YouTube flow plays in the main frame.)
- Both guards re-check the requested visibility after the async query, in case the tab became active again in the meantime.

Note: this branch is based on the commit currently pinned by lunascape-mobile release/v15.5.0 (`e42438c`, PR #231), which is not yet part of `dev-v13.12.0`, so that commit appears in this PR as well.

## Testing

- Compiled and launched in the iOS simulator via lunascape-mobile (`PhoebeMobileStag`, iPhone 16 Pro).
- `:react-native-webview:compileDebugJavaWithJavac` passes in the lunascape-mobile Android project.
- Manual QA still needed on device: YouTube playing → switch tab (audio should continue), PiP active → switch tab (PiP should continue), and non-media tabs still fire `visibilitychange`/detach as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)